### PR TITLE
Added handling when trying to open a dialog when it is already displayed in hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kamo88/react-dialog",
-  "version": "0.0.5",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kamo88/react-dialog",
-      "version": "0.0.5",
+      "version": "0.9.2",
       "license": "ISC",
       "dependencies": {
         "focus-trap-react": "^10.2.1",

--- a/src/components/Dialog/hooks/useDialog.ts
+++ b/src/components/Dialog/hooks/useDialog.ts
@@ -5,12 +5,18 @@ export const useDialog = () => {
 
   const [isOpen, setIsOpen] = useState(false);
 
+  const isOpenRef = useRef(false);
+
   const showDialog = useCallback(() => {
+    if (isOpenRef.current) return;
+    isOpenRef.current = true;
     setIsOpen(true);
     ref.current?.showModal();
   }, []);
 
   const closeDialog = useCallback(() => {
+    if (!isOpenRef.current) return;
+    isOpenRef.current = false;
     setIsOpen(false);
     ref.current?.close();
   }, []);

--- a/src/components/Dialog/hooks/useDialogPromise.ts
+++ b/src/components/Dialog/hooks/useDialogPromise.ts
@@ -18,7 +18,7 @@ export const useDialogPromise = () => {
     }),
   );
 
-  const resolveState = useRef<(value: DialogResponseState) => void>(
+  const resolveState = useRef<((value: DialogResponseState) => void) | null>(
     () => () => {
       // noop
     },
@@ -27,7 +27,7 @@ export const useDialogPromise = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   const showDialog = useCallback(() => {
-    resolveState.current('abort');
+    resolveState.current?.('abort');
     setIsOpen(true);
     ref.current?.showModal();
     promiseState.current = new Promise<DialogResponseState>((resolve) => {
@@ -39,19 +39,19 @@ export const useDialogPromise = () => {
   const closeDialogMain = useCallback(() => {
     setIsOpen(false);
     ref.current?.close();
-    resolveState.current('main');
+    resolveState.current?.('main');
   }, []);
 
   const closeDialogSub = useCallback(() => {
     setIsOpen(false);
     ref.current?.close();
-    resolveState.current('sub');
+    resolveState.current?.('sub');
   }, []);
 
   const closeDialogAbort = useCallback(() => {
     setIsOpen(false);
     ref.current?.close();
-    resolveState.current('abort');
+    resolveState.current?.('abort');
   }, []);
 
   useEffect(() => () => closeDialogAbort(), [closeDialogAbort]);


### PR DESCRIPTION
### PR description

Added handling when trying to open a dialog when it is already displayed in hooks

<details>

<summary>capture</summary>

|     | before | after |
| --- | ------ | ----- |
|     |        |

</details>

### Links

issue: #xxx

### What you need to review

- [ ] changes

### others

others (ex: What we are not doing with this pull request
